### PR TITLE
Added colored facilities to the calendar view.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="https://moodle.oakland.edu/theme/image.php/ou_boost/theme/1567007824/OU_Dark" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/src/App.js
+++ b/src/App.js
@@ -64,7 +64,6 @@ function App() {
           path="/"
           render={props => <Header />}
         />
-        <div className={classes.content}>
           <Route exact path="/" component={Home} />
           <Route path="/login" component={Login} />
           <Route path="/register" component={Register} />
@@ -96,8 +95,6 @@ function App() {
           <Route path="/outdoorcomplex" component={OutdoorComplex} />
           <Route path="/plannedprojects" component={PlannedProjects} />
           <Route path="/policies" component={Policies} />
-
-        </div>
         <Route
           path="/"
           render={props => props.location.pathname !== "/login" && <Footer />}

--- a/src/components/RecCalendarCreate.js
+++ b/src/components/RecCalendarCreate.js
@@ -60,17 +60,18 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-const ToggleButton = ({ room_name, state, setState }) => {
+const ToggleButton = ({ room_name, state, setState, style, ...others }) => {
   const onClick = () => {
     setState(oldState => !oldState);
   };
 
   return (
     <Button
-      style={{ height: 64, margin: 16 }}
+      style={{ height: 64, margin: 16, ...style }}
       variant="contained"
       color={state ? "primary" : "default"}
       onClick={onClick}
+      { ...others }
     >
       {room_name}
     </Button>
@@ -180,10 +181,28 @@ const RecCalendar = () => {
     }
   };
 
+  const getEventColor = (event) => {
+    let eventFacilities = event.facilities;
+
+    const color1 = event.facilities[0].colorCode;
+    if (eventFacilities.length === 1) {
+      return color1;
+    }
+
+    const color2 = event.facilities[1].colorCode;
+    if (eventFacilities.length == 2) {
+      return `linear-gradient(to right, ${color1}, ${color1} 50%, ${color2} 50%)`;
+    }
+
+    const color3 = event.facilities[2].colorCode;
+    return `linear-gradient(to right, ${color1}, ${color1} 33%, ${color2} 33%, ${color2} 66%, ${color3} 66%)`;
+  };
+
   // Determine the properties of an event, including its CSS style.
   const getEventProperties = (event, start, end, isSelected) => {
     return {
-      className: event.temporary ? classes.temporaryEvent : null
+      className: event.temporary ? classes.temporaryEvent : null,
+      style: { backgroundImage: getEventColor(event)}
     };
   };
 
@@ -272,6 +291,8 @@ const RecCalendar = () => {
               state={buttonStates[`${facility.id}`]}
               setState={setButtonState(`${facility.id}`)}
               room_name={facility.name}
+              style={buttonStates[`${facility.id}`] ? 
+                {borderBottom: `12px solid ${facility.colorCode}`} : null}
             />
           );
         })}

--- a/src/components/RecCalendarView.js
+++ b/src/components/RecCalendarView.js
@@ -62,14 +62,14 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-const ToggleButton = ({ room_name, state, setState }) => {
+const ToggleButton = ({ room_name, state, setState, style }) => {
   const onClick = () => {
     setState(oldState => !oldState);
   };
 
   return (
     <Button
-      style={{ height: 64, margin: 16 }}
+      style={{ height: 64, margin: 16, ...style }}
       variant="contained"
       color={state ? "primary" : "default"}
       onClick={onClick}
@@ -148,9 +148,28 @@ const RecCalendar = () => {
     return (now < start && start < maxFutureDate) && (now < end && end < maxFutureDate);
   }
 
+  const getEventColor = (event) => {
+    let eventFacilities = event.facilities;
+
+    const color1 = event.facilities[0].colorCode;
+    if (eventFacilities.length === 1) {
+      return color1;
+    }
+
+    const color2 = event.facilities[1].colorCode;
+    if (eventFacilities.length == 2) {
+      return `linear-gradient(to right, ${color1}, ${color1} 50%, ${color2} 50%)`;
+    }
+
+    const color3 = event.facilities[2].colorCode;
+    return `linear-gradient(to right, ${color1}, ${color1} 33%, ${color2} 33%, ${color2} 66%, ${color3} 66%)`;
+  };
+
   // Determine the properties of an event, including its CSS style.
   const getEventProperties = (event, start, end, isSelected) => {
-    return {};
+    return {
+      style: { backgroundImage: getEventColor(event)}
+    };
   };
 
   // Determine the properties of a calendar time slots, including its CSS style.
@@ -228,6 +247,8 @@ const RecCalendar = () => {
               state={buttonStates[`${facility.id}`]}
               setState={setButtonState(`${facility.id}`)}
               room_name={facility.name}
+              style={buttonStates[`${facility.id}`] ? 
+                {borderBottom: `12px solid ${facility.colorCode}`} : null}
             />
           );
         })}

--- a/src/components/RecDrawer.js
+++ b/src/components/RecDrawer.js
@@ -26,14 +26,20 @@ const RecDrawer = props => {
   return (
     <Drawer open={props.open} onClose={props.onClose}>
       <List>
-        <ListItem button component={Link} to="/aboutus">
+        <ListItem button component={Link} to="/" onClick={props.onClose}>
+          <ListItemText primary="Home" />
+        </ListItem>
+        <ListItem button component={Link} to="/aboutus" onClick={props.onClose}>
           <ListItemText primary="About" />
         </ListItem>
-        <ListItem button component={Link} to='/facilityhours'>
+        <ListItem button component={Link} to='/facilityhours' onClick={props.onClose}>
           <ListItemText primary='Facility Hours' />
         </ListItem>
-        <ListItem button component={Link} to='/stayconnected'>
+        <ListItem button component={Link} to='/stayconnected' onClick={props.onClose}>
           <ListItemText primary='Stay Connected' />
+        </ListItem>
+        <ListItem button component={Link} to='/membership' onClick={props.onClose}>
+          <ListItemText primary='Membership Info' />
         </ListItem>
 
         <Divider />
@@ -44,22 +50,22 @@ const RecDrawer = props => {
         
         <Collapse in={facilities_open} timeout="auto" unmountOnExit>
           <List component="div" disablePadding>
-            <ListItem className={classes.nested} button component={Link} to="/aquaticcenter">
+            <ListItem className={classes.nested} button component={Link} to="/aquaticcenter" onClick={props.onClose}>
               <ListItemText primary="Aquatic Center" />
             </ListItem>
-            <ListItem className={classes.nested} button component={Link} to="/recreationcenter">
+            <ListItem className={classes.nested} button component={Link} to="/recreationcenter" onClick={props.onClose}>
               <ListItemText primary="Recreation Center" />
             </ListItem>
-            <ListItem className={classes.nested} button component={Link} to="/fitnesscourt">
+            <ListItem className={classes.nested} button component={Link} to="/fitnesscourt" onClick={props.onClose}>
               <ListItemText primary="Fitness Court" />
             </ListItem>
-            <ListItem className={classes.nested} button component={Link} to="/outdoorcomplex">
+            <ListItem className={classes.nested} button component={Link} to="/outdoorcomplex" onClick={props.onClose}>
               <ListItemText primary="Outdoor Complex" />
             </ListItem>
-            <ListItem className={classes.nested} button component={Link} to="/plannedprojects">
+            <ListItem className={classes.nested} button component={Link} to="/plannedprojects" onClick={props.onClose}>
               <ListItemText primary="Planned Projects" />
             </ListItem>
-            <ListItem className={classes.nested} button component={Link} to="/policies">
+            <ListItem className={classes.nested} button component={Link} to="/policies" onClick={props.onClose}>
               <ListItemText primary="Policies" />
             </ListItem>
           </List>

--- a/src/components/ReservationForm.js
+++ b/src/components/ReservationForm.js
@@ -192,7 +192,7 @@ const ReservationsDialog = props => {
                         label={bundle_checked[key].name}
                     />
                     {bundle_checked[key].equipment.map(e => (
-                      <div>{`${e.equipment_name} x ${e.count}`}</div>
+                      <div style={{marginLeft: 30, color: 'darkgrey'}}>{`${e.equipment_name} x ${e.count}`}</div>
                     ))}
 
                     </>

--- a/src/components/ReservationManagement.js
+++ b/src/components/ReservationManagement.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
-import {useDispatch, useSelector} from 'react-redux'
-import { makeStyles,} from '@material-ui/core/styles'
-import { 
+import { useDispatch, useSelector } from 'react-redux'
+import { makeStyles, } from '@material-ui/core/styles'
+import {
     Container,
     Table,
     TableBody,
@@ -12,8 +12,6 @@ import {
     TableSortLabel,
     Typography,
     Paper,
-    FormControlLabel,
-    Switch,
     Tabs,
     Tab,
     Box,
@@ -23,7 +21,8 @@ import {
     ButtonGroup,
 } from '@material-ui/core'
 import { get_reservations, put_reservation } from '../actions/reservations'
-import ReservationsDialog from './ReservationForm.js'
+//import ReservationsDialog from './ReservationForm.js'
+import ReservationsListForm from './ReservationsListForm.js'
 import { BrowserRouter as Router, Route, Link } from 'react-router-dom'
 
 const ReservationManagement = () => {
@@ -31,16 +30,16 @@ const ReservationManagement = () => {
     function TabPanel(props) {
         const { children, value, index, ...other } = props;
         return (
-          <Typography
-            component="div"
-            role="tabpanel"
-            hidden={value !== index}
-            id={`simple-tabpanel-${index}`}
-            aria-labelledby={`simple-tab-${index}`}
-            {...other}
-          >
-            <Box p={3}>{children}</Box>
-          </Typography>
+            <Typography
+                component="div"
+                role="tabpanel"
+                hidden={value !== index}
+                id={`simple-tabpanel-${index}`}
+                aria-labelledby={`simple-tab-${index}`}
+                {...other}
+            >
+                <Box p={3}>{children}</Box>
+            </Typography>
         );
     }
 
@@ -75,7 +74,7 @@ const ReservationManagement = () => {
         { id: 'startTime', numeric: true, disablePadding: false, label: 'Start Time' },
         { id: 'endTime', numeric: true, disablePadding: false, label: 'End Time' },
         { id: 'status', numeric: true, disablePadding: false, label: 'Status' },
-        { id: 'actions', numeric: false, disablePadding: false, label: 'Actions'}
+        { id: 'actions', numeric: false, disablePadding: false, label: 'Actions' }
     ];
 
     function EnhancedTableHead(props) {
@@ -85,7 +84,7 @@ const ReservationManagement = () => {
         };
 
         return (
-            <TableHead style={{backgroundColor: '#8e774d'}}> 
+            <TableHead style={{ backgroundColor: '#8e774d' }}>
                 <TableRow>
                     {headCells.map(headCell => (
                         <TableCell
@@ -98,11 +97,11 @@ const ReservationManagement = () => {
                                 active={orderBy === headCell.id}
                                 direction={order}
                                 onClick={createSortHandler(headCell.id)}
-                                >
+                            >
                                 {headCell.label}
                                 {orderBy === headCell.id ? (
                                     <span className={classes.visuallyHidden}>
-                                    {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
+                                        {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
                                     </span>
                                 ) : null}
                             </TableSortLabel>
@@ -143,11 +142,11 @@ const ReservationManagement = () => {
             flexGrow: 1,
             backgroundColor: theme.palette.background.paper,
         },
-        th:{
+        th: {
             backgroudColor: '#8d6e63',
             color: '#8d6e63',
         },
-        createReservation:{
+        createReservation: {
             backgroudColor: '#8d6e63',
             color: '#8d6e63',
             align: "right",
@@ -187,13 +186,14 @@ const ReservationManagement = () => {
 
     const handleOpen = (type, entity) => {
         if (type === 'edit') {
-          setEditable(true)
+            setEditable(true)
         } else {
-          setEditable(false)
+            setEditable(false)
         }
+        console.log(entity)
         setSelectedEntity(entity)
         setOpen(true)
-      }
+    }
 
     const handleClose = () => {
         setOpen(false)
@@ -241,13 +241,13 @@ const ReservationManagement = () => {
 
         if (selectedIndex === -1) {
             newSelected = newSelected.concat(selected, name);
-        } 
+        }
         else if (selectedIndex === 0) {
             newSelected = newSelected.concat(selected.slice(1));
-        } 
+        }
         else if (selectedIndex === selected.length - 1) {
             newSelected = newSelected.concat(selected.slice(0, -1));
-        } 
+        }
         else if (selectedIndex > 0) {
             newSelected = newSelected.concat(
                 selected.slice(0, selectedIndex),
@@ -286,7 +286,7 @@ const ReservationManagement = () => {
                 <AppBar position="static">
                     <Tabs value={value} onChange={handleTabChange} aria-label="simple tabs example" >
                         <Tab label="Pending" />
-                        <Tab label="Approved"/>
+                        <Tab label="Approved" />
                         <Tab label="Denied" />
                         <Tab label="All" />
                     </Tabs>
@@ -329,63 +329,63 @@ const ReservationManagement = () => {
                                         rowCount={rows.length}
                                     />
                                     {rows.length !== 0 ? (
-                                    <TableBody>
-                                        {stableSort(rows, getSorting(order, orderBy))
-                                            .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                                            .map((row) => {
-                                                const isItemSelected = isSelected(row.name);
-                                                return (
-                                                    <TableRow
-                                                        hover
-                                                        onClick={event => handleClick(event, row.name)}
-                                                        aria-checked={isItemSelected}
-                                                        tabIndex={-1}
-                                                        key={row.name}
-                                                        selected={isItemSelected}
-                                                    >
-                                                        <TableCell component="th" scope="row" padding="center">{row.id}</TableCell>
-                                                        <TableCell align="center">{row.event}</TableCell>
-                                                        <TableCell align="center">{row.estimatedParticipants}</TableCell>
-                                                        <TableCell align="center">
-                                                            <div>{new Date (row.startTime).toDateString()}</div>
-                                                            <div>{new Date(row.startTime).toLocaleTimeString()}</div>
-                                                       </TableCell>
-                                                       <TableCell align="center">
-                                                            <div>{new Date (row.endTime).toDateString()}</div>
-                                                            <div>{new Date(row.endTime).toLocaleTimeString()}</div>
-                                                        </TableCell>
-                                                        <TableCell align="center">{row.status}</TableCell>
-                                                        <TableCell align="center">
-                                                            {row.actions}
-                                                            <Grid item>
-                                                                <ButtonGroup size="small" aria-label="small outlined button group">
-                                                                    <Button onClick={() => handleApproval(row)} color="secondary">Approve</Button>
-                                                                    <Button onClick={() => handleDenial(row)} color="secondary">Deny</Button>
-                                                                    <Button onClick={() => handleOpen('edit', row)} color="secondary">Edit</Button>
-                                                                </ButtonGroup>
-                                                            </Grid>
-                                                        </TableCell>
-                                                    </TableRow>
-                                                );
-                                            })
-                                        }
-                                        {emptyRows > 0 && (
-                                            <TableRow style={{ height: (dense ? 33 : 53) * emptyRows }}>
-                                                <TableCell colSpan={6} />
-                                            </TableRow>
-                                        )}
-                                    </TableBody>
+                                        <TableBody>
+                                            {stableSort(rows, getSorting(order, orderBy))
+                                                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                                                .map((row) => {
+                                                    const isItemSelected = isSelected(row.name);
+                                                    return (
+                                                        <TableRow
+                                                            hover
+                                                            onClick={event => handleClick(event, row.name)}
+                                                            aria-checked={isItemSelected}
+                                                            tabIndex={-1}
+                                                            key={row.name}
+                                                            selected={isItemSelected}
+                                                        >
+                                                            <TableCell component="th" scope="row" padding="center">{row.id}</TableCell>
+                                                            <TableCell align="center">{row.event}</TableCell>
+                                                            <TableCell align="center">{row.estimatedParticipants}</TableCell>
+                                                            <TableCell align="center">
+                                                                <div>{new Date(row.startTime).toDateString()}</div>
+                                                                <div>{new Date(row.startTime).toLocaleTimeString()}</div>
+                                                            </TableCell>
+                                                            <TableCell align="center">
+                                                                <div>{new Date(row.endTime).toDateString()}</div>
+                                                                <div>{new Date(row.endTime).toLocaleTimeString()}</div>
+                                                            </TableCell>
+                                                            <TableCell align="center">{row.status}</TableCell>
+                                                            <TableCell align="center">
+                                                                {row.actions}
+                                                                <Grid item>
+                                                                    <ButtonGroup size="small" aria-label="small outlined button group">
+                                                                        <Button onClick={() => handleApproval(row)} color="secondary">Approve</Button>
+                                                                        <Button onClick={() => handleDenial(row)} color="secondary">Deny</Button>
+                                                                        <Button onClick={() => handleOpen('edit', row)} color="secondary">Edit</Button>
+                                                                    </ButtonGroup>
+                                                                </Grid>
+                                                            </TableCell>
+                                                        </TableRow>
+                                                    );
+                                                })
+                                            }
+                                            {emptyRows > 0 && (
+                                                <TableRow style={{ height: (dense ? 33 : 53) * emptyRows }}>
+                                                    <TableCell colSpan={6} />
+                                                </TableRow>
+                                            )}
+                                        </TableBody>
                                     ) : (
-                                        <div style={{ padding: '20px' }}>
-                                          <Typography>No reservations for this criteria</Typography>
-                                        </div>
-                                      )}
+                                            <div style={{ padding: '20px' }}>
+                                                <Typography>No reservations for this criteria</Typography>
+                                            </div>
+                                        )}
                                 </Table>
-                                <ReservationsDialog
+                                <ReservationsListForm
                                     open={open}
                                     handleClose={handleClose}
                                     entity={selectedEntity}
-                                    editable={editable}
+                                    editable
                                     create={false}
                                 />
                             </div>
@@ -412,7 +412,7 @@ const ReservationManagement = () => {
                         />*/}
                     </Container>
                 </TabPanel>
-                
+
                 <TabPanel value={value} index={1}>
                     <Container>
                         <Paper className={classes.paper}>
@@ -432,57 +432,57 @@ const ReservationManagement = () => {
                                         rowCount={rows.length}
                                     />
                                     {rows.length !== 0 ? (
-                                    <TableBody>
-                                        {stableSort(rows, getSorting(order, orderBy))
-                                            .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                                            .map((row, index) => {
-                                                const isItemSelected = isSelected(row.name);
+                                        <TableBody>
+                                            {stableSort(rows, getSorting(order, orderBy))
+                                                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                                                .map((row, index) => {
+                                                    const isItemSelected = isSelected(row.name);
 
-                                                return (
-                                                    <TableRow
-                                                        hover
-                                                        onClick={event => handleClick(event, row.name)}
-                                                        aria-checked={isItemSelected}
-                                                        tabIndex={-1}
-                                                        key={row.name}
-                                                        selected={isItemSelected}
-                                                    >
-                                                        <TableCell component="th" scope="row" padding="center">{row.id}</TableCell>
-                                                        <TableCell align="center">{row.event}</TableCell>
-                                                        <TableCell align="center">{row.estimatedParticipants}</TableCell>
-                                                        <TableCell align="center">
-                                                            <div>{new Date (row.startTime).toDateString()}</div>
-                                                            <div>{new Date(row.startTime).toLocaleTimeString()}</div>
-                                                       </TableCell>
-                                                       <TableCell align="center">
-                                                            <div>{new Date (row.endTime).toDateString()}</div>
-                                                            <div>{new Date(row.endTime).toLocaleTimeString()}</div>
-                                                        </TableCell>
-                                                        <TableCell align="center">{row.status}</TableCell>
-                                                        <TableCell align="center">
-                                                            {row.actions}   
-                                                            <ButtonGroup fullWidth aria-label="full width outlined button group">
-                                                                <Button onClick={() => handleDenial(row)} color="secondary">Deny</Button>
-                                                                <Button onClick={() => handleOpen('edit', row)} color="secondary">Edit</Button>
-                                                            </ButtonGroup>
-                                                        </TableCell>
-                                                    </TableRow>
-                                                );
-                                            })
-                                        }
-                                        {emptyRows > 0 && (
-                                            <TableRow style={{ height: (dense ? 33 : 53) * emptyRows }}>
-                                                <TableCell colSpan={6} />
-                                            </TableRow>
-                                        )}
-                                    </TableBody>
+                                                    return (
+                                                        <TableRow
+                                                            hover
+                                                            onClick={event => handleClick(event, row.name)}
+                                                            aria-checked={isItemSelected}
+                                                            tabIndex={-1}
+                                                            key={row.name}
+                                                            selected={isItemSelected}
+                                                        >
+                                                            <TableCell component="th" scope="row" padding="center">{row.id}</TableCell>
+                                                            <TableCell align="center">{row.event}</TableCell>
+                                                            <TableCell align="center">{row.estimatedParticipants}</TableCell>
+                                                            <TableCell align="center">
+                                                                <div>{new Date(row.startTime).toDateString()}</div>
+                                                                <div>{new Date(row.startTime).toLocaleTimeString()}</div>
+                                                            </TableCell>
+                                                            <TableCell align="center">
+                                                                <div>{new Date(row.endTime).toDateString()}</div>
+                                                                <div>{new Date(row.endTime).toLocaleTimeString()}</div>
+                                                            </TableCell>
+                                                            <TableCell align="center">{row.status}</TableCell>
+                                                            <TableCell align="center">
+                                                                {row.actions}
+                                                                <ButtonGroup fullWidth aria-label="full width outlined button group">
+                                                                    <Button onClick={() => handleDenial(row)} color="secondary">Deny</Button>
+                                                                    <Button onClick={() => handleOpen('edit', row)} color="secondary">Edit</Button>
+                                                                </ButtonGroup>
+                                                            </TableCell>
+                                                        </TableRow>
+                                                    );
+                                                })
+                                            }
+                                            {emptyRows > 0 && (
+                                                <TableRow style={{ height: (dense ? 33 : 53) * emptyRows }}>
+                                                    <TableCell colSpan={6} />
+                                                </TableRow>
+                                            )}
+                                        </TableBody>
                                     ) : (
-                                        <div style={{ padding: '20px' }}>
-                                          <Typography>No reservations for this criteria</Typography>
-                                        </div>
-                                      )}
+                                            <div style={{ padding: '20px' }}>
+                                                <Typography>No reservations for this criteria</Typography>
+                                            </div>
+                                        )}
                                 </Table>
-                                <ReservationsDialog
+                                <ReservationsListForm
                                     open={open}
                                     handleClose={handleClose}
                                     entity={selectedEntity}
@@ -532,57 +532,57 @@ const ReservationManagement = () => {
                                         rowCount={rows.length}
                                     />
                                     {rows.length !== 0 ? (
-                                    <TableBody>
-                                        {stableSort(rows, getSorting(order, orderBy))
-                                            .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                                            .map((row, index) => {
-                                                const isItemSelected = isSelected(row.name);
+                                        <TableBody>
+                                            {stableSort(rows, getSorting(order, orderBy))
+                                                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                                                .map((row, index) => {
+                                                    const isItemSelected = isSelected(row.name);
 
-                                                return (
-                                                    <TableRow
-                                                        hover
-                                                        onClick={event => handleClick(event, row.name)}
-                                                        aria-checked={isItemSelected}
-                                                        tabIndex={-1}
-                                                        key={row.name}
-                                                        selected={isItemSelected}
-                                                    >
-                                                        <TableCell component="th" scope="row" padding="center">{row.id}</TableCell>
-                                                        <TableCell align="center">{row.event}</TableCell>
-                                                        <TableCell align="center">{row.estimatedParticipants}</TableCell>
-                                                        <TableCell align="center">
-                                                            <div>{new Date (row.startTime).toDateString()}</div>
-                                                            <div>{new Date(row.startTime).toLocaleTimeString()}</div>
-                                                       </TableCell>
-                                                       <TableCell align="center">
-                                                            <div>{new Date (row.endTime).toDateString()}</div>
-                                                            <div>{new Date(row.endTime).toLocaleTimeString()}</div>
-                                                        </TableCell>
-                                                        <TableCell align="center">{row.status}</TableCell>
-                                                        <TableCell align="center">
-                                                            {row.actions}
-                                                            <ButtonGroup fullWidth aria-label="full width outlined button group">
-                                                                <Button onClick={() => handleApproval(row)}color="secondary">Approve</Button>
-                                                                <Button onClick={() => handleOpen('edit', row)} color="secondary">Edit</Button>
-                                                            </ButtonGroup>
-                                                        </TableCell>
-                                                    </TableRow>
-                                                );
-                                            })
-                                        }
-                                        {emptyRows > 0 && (
-                                            <TableRow style={{ height: (dense ? 33 : 53) * emptyRows }}>
-                                                <TableCell colSpan={6} />
-                                            </TableRow>
-                                        )}
-                                    </TableBody>
+                                                    return (
+                                                        <TableRow
+                                                            hover
+                                                            onClick={event => handleClick(event, row.name)}
+                                                            aria-checked={isItemSelected}
+                                                            tabIndex={-1}
+                                                            key={row.name}
+                                                            selected={isItemSelected}
+                                                        >
+                                                            <TableCell component="th" scope="row" padding="center">{row.id}</TableCell>
+                                                            <TableCell align="center">{row.event}</TableCell>
+                                                            <TableCell align="center">{row.estimatedParticipants}</TableCell>
+                                                            <TableCell align="center">
+                                                                <div>{new Date(row.startTime).toDateString()}</div>
+                                                                <div>{new Date(row.startTime).toLocaleTimeString()}</div>
+                                                            </TableCell>
+                                                            <TableCell align="center">
+                                                                <div>{new Date(row.endTime).toDateString()}</div>
+                                                                <div>{new Date(row.endTime).toLocaleTimeString()}</div>
+                                                            </TableCell>
+                                                            <TableCell align="center">{row.status}</TableCell>
+                                                            <TableCell align="center">
+                                                                {row.actions}
+                                                                <ButtonGroup fullWidth aria-label="full width outlined button group">
+                                                                    <Button onClick={() => handleApproval(row)} color="secondary">Approve</Button>
+                                                                    <Button onClick={() => handleOpen('edit', row)} color="secondary">Edit</Button>
+                                                                </ButtonGroup>
+                                                            </TableCell>
+                                                        </TableRow>
+                                                    );
+                                                })
+                                            }
+                                            {emptyRows > 0 && (
+                                                <TableRow style={{ height: (dense ? 33 : 53) * emptyRows }}>
+                                                    <TableCell colSpan={6} />
+                                                </TableRow>
+                                            )}
+                                        </TableBody>
                                     ) : (
-                                        <div style={{ padding: '20px' }}>
-                                          <Typography>No reservations for this criteria</Typography>
-                                        </div>
-                                      )}
+                                            <div style={{ padding: '20px' }}>
+                                                <Typography>No reservations for this criteria</Typography>
+                                            </div>
+                                        )}
                                 </Table>
-                                <ReservationsDialog
+                                <ReservationsListForm
                                     open={open}
                                     handleClose={handleClose}
                                     entity={selectedEntity}
@@ -632,54 +632,54 @@ const ReservationManagement = () => {
                                         rowCount={rows.length}
                                     />
                                     {rows.length !== 0 ? (
-                                    <TableBody>
-                                        {stableSort(rows, getSorting(order, orderBy))
-                                            .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                                            .map((row, index) => {
-                                                const isItemSelected = isSelected(row.name);
+                                        <TableBody>
+                                            {stableSort(rows, getSorting(order, orderBy))
+                                                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                                                .map((row, index) => {
+                                                    const isItemSelected = isSelected(row.name);
 
-                                                return (
-                                                    <TableRow
-                                                        hover
-                                                        onClick={event => handleClick(event, row.name)}
-                                                        aria-checked={isItemSelected}
-                                                        tabIndex={-1}
-                                                        key={row.name}
-                                                        selected={isItemSelected}
-                                                    >
-                                                        <TableCell component="th" scope="row" padding="center">{row.id}</TableCell>
-                                                        <TableCell align="center">{row.event}</TableCell>
-                                                        <TableCell align="center">{row.estimatedParticipants}</TableCell>
-                                                        <TableCell align="center">
-                                                            <div>{new Date (row.startTime).toDateString()}</div>
-                                                            <div>{new Date (row.startTime).toLocaleTimeString()}</div>
-                                                       </TableCell>
-                                                       <TableCell align="center">
-                                                            <div>{new Date (row.endTime).toDateString()}</div>
-                                                            <div>{new Date (row.endTime).toLocaleTimeString()}</div>
-                                                        </TableCell>
-                                                        <TableCell align="center">{row.status}</TableCell>
-                                                        <TableCell align="center">
-                                                            {row.actions}
-                                                            <ButtonGroup fullWidth aria-label="full width outlined button group">
-                                                                <Button onClick={() => handleOpen('view', row)} color="secondary">View</Button>
-                                                            </ButtonGroup>
-                                                        </TableCell>
-                                                    </TableRow>
-                                                );
-                                            })
-                                        }
-                                        {emptyRows > 0 && (
-                                            <TableRow style={{ height: (dense ? 33 : 53) * emptyRows }}>
-                                                <TableCell colSpan={6} />
-                                            </TableRow>
-                                        )}
-                                    </TableBody>
+                                                    return (
+                                                        <TableRow
+                                                            hover
+                                                            onClick={event => handleClick(event, row.name)}
+                                                            aria-checked={isItemSelected}
+                                                            tabIndex={-1}
+                                                            key={row.name}
+                                                            selected={isItemSelected}
+                                                        >
+                                                            <TableCell component="th" scope="row" padding="center">{row.id}</TableCell>
+                                                            <TableCell align="center">{row.event}</TableCell>
+                                                            <TableCell align="center">{row.estimatedParticipants}</TableCell>
+                                                            <TableCell align="center">
+                                                                <div>{new Date(row.startTime).toDateString()}</div>
+                                                                <div>{new Date(row.startTime).toLocaleTimeString()}</div>
+                                                            </TableCell>
+                                                            <TableCell align="center">
+                                                                <div>{new Date(row.endTime).toDateString()}</div>
+                                                                <div>{new Date(row.endTime).toLocaleTimeString()}</div>
+                                                            </TableCell>
+                                                            <TableCell align="center">{row.status}</TableCell>
+                                                            <TableCell align="center">
+                                                                {row.actions}
+                                                                <ButtonGroup fullWidth aria-label="full width outlined button group">
+                                                                    <Button onClick={() => handleOpen('view', row)} color="secondary">View</Button>
+                                                                </ButtonGroup>
+                                                            </TableCell>
+                                                        </TableRow>
+                                                    );
+                                                })
+                                            }
+                                            {emptyRows > 0 && (
+                                                <TableRow style={{ height: (dense ? 33 : 53) * emptyRows }}>
+                                                    <TableCell colSpan={6} />
+                                                </TableRow>
+                                            )}
+                                        </TableBody>
                                     ) : (
-                                        <div style={{ padding: '20px' }}>
-                                          <Typography>No reservations for this criteria</Typography>
-                                        </div>
-                                      )}
+                                            <div style={{ padding: '20px' }}>
+                                                <Typography>No reservations for this criteria</Typography>
+                                            </div>
+                                        )}
                                 </Table>
                             </div>
                             <TablePagination
@@ -705,7 +705,7 @@ const ReservationManagement = () => {
                         />*/}
                     </Container>
                 </TabPanel>
-            </div>   
+            </div>
         </div>
     );
 }

--- a/src/components/ReservationSubmitted.js
+++ b/src/components/ReservationSubmitted.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
-import { Container } from '@material-ui/core'
+import { Button, Container } from '@material-ui/core'
+import { Link } from 'react-router-dom'
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
     overflowX: 'auto'
@@ -19,8 +20,13 @@ const useStyles = makeStyles({
   },
   th: {
     backgroundColor: '#8d6e63'
+  },
+  linkButtons: {
+    width: '90%',
+    display: 'flex',
+    justifyContent: 'space-around'
   }
-})
+}))
 
 const ReservationSubmitted = () => {
   const classes = useStyles()
@@ -33,6 +39,11 @@ const ReservationSubmitted = () => {
           <p>
             Please wait until an administrator approves your request.
           </p>
+          <div className={classes.linkButtons}>
+            <Button variant='contained' color='secondary' component={Link} to="/">Home</Button>
+            <Button variant='contained' color='secondary' component={Link} to="/my-reservations">My Reservations</Button>
+            <Button variant='contained' color='secondary' component={Link} to="/create-reservation">Create Reservation</Button>
+          </div>
           <br />
         </Container>
         <br />

--- a/src/components/entities/UserManagement.js
+++ b/src/components/entities/UserManagement.js
@@ -50,7 +50,8 @@ const useStyles = makeStyles(theme => ({
     marginTop: '5vh',
     height: '100%',
     display: 'flex',
-    flexDirection: 'column'
+    flexDirection: 'column',
+    margin: 24
   },
   cardHeader: {
     backgroundColor: theme.palette.primary.light,
@@ -142,7 +143,7 @@ const UserManagement = props => {
                 <TableCell align='right'>{row.lastModifiedDate}</TableCell>
                 <TableCell align='right'>{row.lastModifiedBy}</TableCell>
                 <TableCell align='center'>
-                  <ButtonGroup size='small' variant='contained' color='primary'>
+                  <ButtonGroup size='small'>
                     <Button onClick={() => handleOpen('view', row)}>
                       View
                     </Button>
@@ -423,6 +424,8 @@ const UsersDialog = props => {
             </Grid>
             <Grid item>
               <Button
+                variant='outlined'
+                color='secondary'
                 className={classes.formControl}
                 disabled={!editable}
                 onClick={() => handleDeleteMembership(membership)}

--- a/src/index.js
+++ b/src/index.js
@@ -9,17 +9,17 @@ import './index.css'
 import * as serviceWorker from './serviceWorker'
 const theme = createMuiTheme({
   palette: {
-    primary: {
-      light: '#B89F74', // Primary Light
-      main: '#877148', // Heritage Gold
-      dark: '#58461F', // Primary Dark
-      contrastText: '#FFF'
+      primary: {
+      light: '#b89f74',
+      main: '#877148',
+      dark: '#58461f',
+      contrastText: '#fff'
     },
     secondary: {
-      light: '#00B398', // Accent Teal
-      main: '#0086BF', // Accent Blue
-      dark: 'purple', // Accent Purple
-      contrastText: '#FFF'
+      light: '#56a2ea',
+      main: '#0074b7',
+      dark: '#004987',
+      contrastText: '#fff'
     }
   }
 })


### PR DESCRIPTION
Each facility is already associated with a color, editable by admins from the Facility management view.

This change adds an underline to each facility in the calendar view, which appears when it is selected, corresponding to that assigned color. Additionally, reservations in the calendar will display the colors of up to three of their associated facilities.

Below is a preview:

![Capture](https://user-images.githubusercontent.com/4635334/70094069-b2d6a580-15ef-11ea-99f9-23a84e1f98bc.PNG)

One issue that potentially came up with this change is that the colors may be too harsh; however, admins may select any color they want from the facility editor; if they have a lighter set of colors they wish to use, they may simply specify them. With the current mock data, all facilities are gray by default; we will likely want to modify this for the demo.

Additionally, I researched adding a color picker dialog for the facility editor rather than a text field, but there ended up being too many quirks with the feature, so I dropped it.